### PR TITLE
Improve push demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
-/nativephp
 NUL
 .DS_Store
 google-services.json

--- a/app/Http/Controllers/Auth/WorkOSController.php
+++ b/app/Http/Controllers/Auth/WorkOSController.php
@@ -51,4 +51,34 @@ class WorkOSController extends Controller
             return redirect()->route('home');
         }
     }
+
+    public function deleteAccount()
+    {
+        try {
+            $workosProfile = SecureStorage::get('workos_profile');
+
+            if (!$workosProfile) {
+                return response()->json(['error' => 'No WorkOS profile found'], 400);
+            }
+
+            $profile = json_decode($workosProfile, true);
+            $userId = $profile['id'];
+
+            $userManagement = new UserManagement;
+            $userManagement->deleteUser($userId);
+
+            $this->clearWorkOSData();
+
+            return response()->json(['success' => true]);
+        } catch (\Exception $e) {
+            return response()->json(['error' => 'Failed to delete WorkOS account'], 500);
+        }
+    }
+
+    protected function clearWorkOSData()
+    {
+        SecureStorage::delete('token');
+        SecureStorage::delete('workos_profile');
+        session()->forget('user');
+    }
 }

--- a/app/Livewire/Auth/DeleteAccount.php
+++ b/app/Livewire/Auth/DeleteAccount.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Livewire\Auth;
+
+use App\Services\AccountDeletionService;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Native\Mobile\Events\Alert\ButtonPressed;
+use Native\Mobile\Facades\Dialog;
+
+class DeleteAccount extends Component
+{
+    public function confirmDelete()
+    {
+        Dialog::alert(
+            'Delete Account',
+            'Are you sure you want to delete your account? This action cannot be undone.',
+            ['Cancel', 'Delete Account']
+        );
+    }
+
+    #[On('native:'.ButtonPressed::class)]
+    public function handleConfirmation($index, $label)
+    {
+        if ($index === 1) {
+            $this->deleteAccount(app(AccountDeletionService::class));
+        }
+    }
+
+    public function deleteAccount(AccountDeletionService $accountDeletionService)
+    {
+        $result = $accountDeletionService->deleteAccount();
+        
+        if ($result['success']) {
+            Dialog::toast($result['message']);
+            return redirect()->route('home');
+        } else {
+            Dialog::toast($result['message']);
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.auth.delete-account');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Http\Controllers\Auth\WorkOSController;
+use App\Services\AccountDeletionService;
 use App\Services\KitchenSinkService;
 use Illuminate\Support\ServiceProvider;
 
@@ -14,6 +16,13 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->singleton(KitchenSinkService::class, function ($app) {
             return new KitchenSinkService;
+        });
+
+        $this->app->singleton(AccountDeletionService::class, function ($app) {
+            return new AccountDeletionService(
+                $app->make(KitchenSinkService::class),
+                $app->make(WorkOSController::class)
+            );
         });
     }
 

--- a/app/Providers/HttpClientMacroServiceProvider.php
+++ b/app/Providers/HttpClientMacroServiceProvider.php
@@ -30,14 +30,14 @@ class HttpClientMacroServiceProvider extends ServiceProvider
                 ])
                 ->timeout(30)
                 ->throw(function ($response, $e) {
-                    SecureStorage::set('token', null);
-                    session()->forget('user');
                     throw new ApiAuthenticationException($response->json('message'));
                 });
+
             if ($useToken) {
                 if (is_null(SecureStorage::get('token'))) {
-                    throw new ApiAuthenticationException;
+                    throw new ApiAuthenticationException('No token');
                 }
+
                 $request->withToken(SecureStorage::get('token'));
             }
 

--- a/app/Services/AccountDeletionService.php
+++ b/app/Services/AccountDeletionService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use App\Http\Controllers\Auth\WorkOSController;
+use Native\Mobile\Facades\SecureStorage;
+
+class AccountDeletionService
+{
+    public function __construct(
+        private KitchenSinkService $kitchenSinkService,
+        private WorkOSController $workOSController
+    ) {}
+
+    public function deleteAccount()
+    {
+        $workosProfile = SecureStorage::get('workos_profile');
+        
+        if ($workosProfile) {
+            return $this->deleteWorkOSAccount();
+        }
+
+        return $this->deleteRegularAccount();
+    }
+
+    private function deleteWorkOSAccount()
+    {
+        $response = $this->workOSController->deleteAccount();
+        
+        if ($response->getStatusCode() === 200) {
+            return ['success' => true, 'message' => 'WorkOS account deleted successfully'];
+        }
+        
+        return ['success' => false, 'message' => 'Failed to delete WorkOS account'];
+    }
+
+    private function deleteRegularAccount()
+    {
+        $success = $this->kitchenSinkService->deleteAccount();
+        
+        if ($success) {
+            return ['success' => true, 'message' => 'Account deleted successfully'];
+        }
+        
+        return ['success' => false, 'message' => 'Failed to delete account'];
+    }
+
+    public function isWorkOSUser()
+    {
+        return SecureStorage::get('workos_profile') !== null;
+    }
+}

--- a/app/Services/KitchenSinkService.php
+++ b/app/Services/KitchenSinkService.php
@@ -63,9 +63,27 @@ class KitchenSinkService
         return $response;
     }
 
+    public function deleteAccount()
+    {
+        try {
+            $response = Http::kitchenSink(true)->post('delete');
+
+            if ($response->successful()) {
+                $this->logout();
+                return true;
+            }
+
+            return false;
+        } catch (ApiAuthenticationException $e) {
+            Dialog::alert('API Error', $e->getMessage());
+            return false;
+        }
+    }
+
     public function logout()
     {
         SecureStorage::delete('token');
+        SecureStorage::delete('workos_profile');
         session()->forget('user');
     }
 }

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -75,6 +75,8 @@
                 <flux:navlist.item icon="arrow-right-start-on-rectangle" href=" {{route('logout')}}">
                     Logout
                 </flux:navlist.item>
+                <flux:menu.separator/>
+                <livewire:auth.delete-account/>
             </flux:menu>
         </flux:dropdown>
     @endif

--- a/resources/views/livewire/auth/delete-account.blade.php
+++ b/resources/views/livewire/auth/delete-account.blade.php
@@ -1,0 +1,3 @@
+<flux:navlist.item icon="trash" wire:click="confirmDelete" variant="danger">
+    Delete Account
+</flux:navlist.item>


### PR DESCRIPTION
On iOS, I need to be a bit more brutal to get the token to reliably come through and it became easier to split the token request from the moment of generating, whilst also making the token visible to the user.

I haven't tested this on Android yet